### PR TITLE
Fix asset precompilation errors and bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-08-04
+
+### Fixed
+- **Asset Precompilation**: Fixed production asset precompilation errors
+  - Added missing `analysis.css` to precompiled assets list
+  - Added all JavaScript files from results subdirectory (`view_toggles.js`, `chart_renderer.js`, `table_manager.js`)
+  - Added external library assets (`chartkick.js`, `Chart.bundle.js`) to precompilation
+  - Resolved "Asset was not declared to be precompiled in production" errors
+  - Ensures all required assets are properly compiled for production deployment
+
 ## [0.4.0] - 2025-08-04
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pg_insights (0.4.0)
+    pg_insights (0.4.1)
       chartkick (~> 5.1)
       rails (>= 6.1)
 

--- a/lib/pg_insights/engine.rb
+++ b/lib/pg_insights/engine.rb
@@ -10,10 +10,18 @@ module PgInsights
       app.config.assets.precompile += %w[
         pg_insights/application.css
         pg_insights/application.js
+        pg_insights/analysis.css
         pg_insights/health.css
         pg_insights/health.js
         pg_insights/results.css
         pg_insights/results.js
+        pg_insights/query_comparison.js
+        pg_insights/plan_performance.js
+        pg_insights/results/view_toggles.js
+        pg_insights/results/chart_renderer.js
+        pg_insights/results/table_manager.js
+        chartkick.js
+        Chart.bundle.js
       ]
     end
 

--- a/lib/pg_insights/version.rb
+++ b/lib/pg_insights/version.rb
@@ -1,3 +1,3 @@
 module PgInsights
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Added missing CSS and JavaScript files, including external libraries, to the precompiled assets list to resolve production asset precompilation errors. Updated the version to 0.4.1 and documented the changes in the changelog.